### PR TITLE
removing 'taguri' from svn info

### DIFF
--- a/lib/svn_wc.rb
+++ b/lib/svn_wc.rb
@@ -759,7 +759,7 @@ module SvnWc
                      copyfrom_rev copyfrom_url conflict_wrk 
                      conflict_new has_wc_info repos_UUID
                      checksum prop_time text_time prejfile
-                     schedule taguri lock rev dup url URL
+                     schedule lock rev dup url URL
                     ) # changelist depth size tree_conflict working_size
 
       begin


### PR DESCRIPTION
Without this, `svn.info` won't work, and fails with this error:

```
SvnWc::RepoAccessError: cant get info: undefined method `taguri' for class `Svn::Ext::Client::Svn_info_t'
```
